### PR TITLE
Remove Intel AMI BXT flash device from PCI400C-A => has EPROM.

### DIFF
--- a/src/machine/m_at_386dx_486.c
+++ b/src/machine/m_at_386dx_486.c
@@ -915,7 +915,6 @@ machine_at_pci400ca_init(const machine_t *model)
     pci_register_slot(0x02, PCI_CARD_SOUTHBRIDGE, 0, 0, 0, 0);
     device_add(&keyboard_ps2_ami_device);
     device_add(&sio_device);
-    device_add(&intel_flash_bxt_ami_device);
 
     device_add(&i420tx_device);
     device_add(&ncr53c810_onboard_pci_device);


### PR DESCRIPTION
Summary
=======
Remove the intel flash device from the PCI400C-A, as the board only has an EPROM, no flash chip.

Checklist
=========
* [ ] Closes #xxx
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/

References
==========
https://theretroweb.com/motherboards/3237 see pictures: only EPROM chip, no intel flash
